### PR TITLE
Feat/model instance deletion via lens api and model api

### DIFF
--- a/packages/models/README.md
+++ b/packages/models/README.md
@@ -125,6 +125,7 @@ const counterModel = model({
 | ------------ | ------------------------------------------- | ------------------------- |
 | `$instances` | `Store<Record<string, Data>>`               | All live instances        |
 | `create`     | `EventCallable<{ id: string; data: Data }>` | Creates a new instance    |
+| `delete`     | `EventCallable<string>`                     | Removes instance by id    |
 | `lens`       | `Lens`                                      | Targeting API (see below) |
 
 **Creating instances:**
@@ -135,6 +136,14 @@ counterModel.create({ id: "b", data: { count: 10 } });
 
 counterModel.$instances.getState();
 // { a: { count: 0 }, b: { count: 10 } }
+```
+
+**Removing instance:**
+
+`delete` accepts an instance id and drops that key from `$instances`.
+
+```ts
+counterModel.delete("a");
 ```
 
 **`model.static(data)`**
@@ -240,6 +249,18 @@ counterModel.lens
   .count.target();
 ```
 
+#### `lens.delete()`
+
+Returns an `EventCallable<void>`. When called, it removes every instance in the current lens selection by id:
+
+```ts
+const purgeZero = createEvent<void>();
+sample({
+  clock: purgeZero,
+  target: counterModel.lens.where(({ count }) => count === 0).delete(),
+});
+```
+
 ---
 
 ### `ref(model)` and `ref(union)`
@@ -301,6 +322,7 @@ const dashboardModel = model({
 - **`.lens.only(...keys)`**: restrict variants (mutable chain)
 - **`.lens.where(...)`**: filter instances (mutable chain). Use `ctx.match({ ... })` for variant-specific predicates.
 - **`.lens.match({ ... })`**: build per-variant sub-lenses and merge their targets into one `EventCallable` (usable as a `sample` target).
+- **`.lens.delete()`**: returns `EventCallable` that removes every instance in the current selection when called (usable as a `sample` target).
 
 Examples for `.only(...)`:
 

--- a/packages/models/__tests__/lens.test.ts
+++ b/packages/models/__tests__/lens.test.ts
@@ -206,6 +206,76 @@ describe("lens.where() filtering via scope", () => {
 });
 
 // ---------------------------------------------------------------------------
+// lens.delete()
+// ---------------------------------------------------------------------------
+
+describe("lens.delete() via scope", () => {
+  test("removes instances matching where()", async () => {
+    const m = makeTagged();
+    const trigger = createEvent<void>();
+    sample({ clock: trigger, target: m.lens.where(({ tag }) => tag === "a").delete() });
+
+    m.create({ id: "1", data: { tag: "a", value: 0 } });
+    m.create({ id: "2", data: { tag: "b", value: 0 } });
+    m.create({ id: "3", data: { tag: "a", value: 0 } });
+
+    const scope = forkWithInstances(m);
+    await allSettled(trigger, { scope });
+
+    const instances = scope.getState(m.$instances);
+    expect(instances["1"]).toBeUndefined();
+    expect(instances["3"]).toBeUndefined();
+    expect(instances["2"]?.tag).toBe("b");
+  });
+
+  test("without where removes all instances", async () => {
+    const m = makeCounter();
+    const trigger = createEvent<void>();
+    sample({ clock: trigger, target: m.lens.delete() });
+
+    m.create({ id: "x", data: { count: 1 } });
+    m.create({ id: "y", data: { count: 2 } });
+
+    const scope = forkWithInstances(m);
+    await allSettled(trigger, { scope });
+
+    expect(scope.getState(m.$instances)).toEqual({});
+  });
+
+  test("first().delete() removes a single instance", async () => {
+    const m = makeCounter();
+    const trigger = createEvent<void>();
+    sample({ clock: trigger, target: m.lens.first().delete() });
+
+    m.create({ id: "a", data: { count: 0 } });
+    m.create({ id: "b", data: { count: 0 } });
+
+    const scope = forkWithInstances(m);
+    await allSettled(trigger, { scope });
+
+    const instances = scope.getState(m.$instances);
+    expect(Object.keys(instances)).toHaveLength(1);
+    expect(instances["b"]).toBeDefined();
+  });
+
+  test("matching no instances is a no-op", async () => {
+    const m = makeTagged();
+    const trigger = createEvent<void>();
+    sample({
+      clock: trigger,
+      target: m.lens.where(({ tag }) => tag === "b").delete(),
+    });
+
+    m.create({ id: "1", data: { tag: "a", value: 0 } });
+
+    const scope = forkWithInstances(m);
+    await allSettled(trigger, { scope });
+
+    expect(scope.getState(m.$instances)["1"]?.tag).toBe("a");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // lens.first() / lens.last()
 // ---------------------------------------------------------------------------
 

--- a/packages/models/__tests__/model.test.ts
+++ b/packages/models/__tests__/model.test.ts
@@ -363,3 +363,111 @@ describe("instance creation", () => {
     expect(instances["3"]).toMatchObject({ n: 30 });
   });
 });
+
+// ---------------------------------------------------------------------------
+// instance deletion
+// ---------------------------------------------------------------------------
+
+describe("instance deletion", () => {
+  test("delete removes existing instance from $instances", () => {
+    const m = model({
+      contract: contract({ value: define.store(define.static<number>(), 0) })(),
+      fn: ({ value }) => ({ value }),
+    });
+
+    m.create({ id: "a", data: { value: 1 } });
+    m.create({ id: "b", data: { value: 2 } });
+
+    m.delete("a");
+
+    const instances = m.$instances.getState();
+    expect(Object.keys(instances)).toHaveLength(1);
+    expect(instances["a"]).toBeUndefined();
+    expect(instances["b"]).toMatchObject({ value: 2 });
+  });
+
+  test("delete with unknown id keeps instances unchanged", () => {
+    const m = model({
+      contract: contract({ value: define.store(define.static<number>(), 0) })(),
+      fn: ({ value }) => ({ value }),
+    });
+
+    m.create({ id: "x", data: { value: 10 } });
+    m.create({ id: "y", data: { value: 20 } });
+
+    m.delete("missing");
+
+    expect(m.$instances.getState()).toMatchObject({
+      x: { value: 10 },
+      y: { value: 20 },
+    });
+  });
+
+  test("delete all instances one by one leaves $instances empty", () => {
+    const m = model({
+      contract: contract({ n: define.store(define.static<number>(), 0) })(),
+      fn: ({ n }) => ({ n }),
+    });
+
+    m.create({ id: "1", data: { n: 10 } });
+    m.create({ id: "2", data: { n: 20 } });
+    m.create({ id: "3", data: { n: 30 } });
+
+    m.delete("2");
+    m.delete("1");
+    m.delete("3");
+
+    expect(m.$instances.getState()).toEqual({});
+  });
+
+  test("instance deletion via fork does not affect global $instances", async () => {
+    const m = model({
+      contract: contract({ x: define.store(define.static<number>(), 0) })(),
+      fn: ({ x }) => ({ x }),
+    });
+
+    m.create({ id: "shared", data: { x: 5 } });
+
+    const scope = fork();
+
+    await allSettled(m.delete, {
+      scope,
+      params: "shared",
+    });
+
+    // Global state should not be changed
+    expect(m.$instances.getState()).toMatchObject({
+      shared: { x: 5 },
+    });
+    // Scope should have deletion result
+    expect(scope.getState(m.$instances)).toEqual({});
+  });
+
+  test("two forks with same model delete independently", async () => {
+    const m = model({
+      contract: contract({
+        label: define.store(define.static<string>(), ""),
+      })(),
+      fn: ({ label }) => ({ label }),
+    });
+
+    const scope1 = fork();
+    const scope2 = fork();
+
+    await allSettled(m.create, {
+      scope: scope1,
+      params: { id: "same-id", data: { label: "scope-1" } },
+    });
+    await allSettled(m.create, {
+      scope: scope2,
+      params: { id: "same-id", data: { label: "scope-2" } },
+    });
+
+    await allSettled(m.delete, { scope: scope1, params: "same-id" });
+
+    expect(scope1.getState(m.$instances)["same-id"]).toBeUndefined();
+    expect(scope2.getState(m.$instances)["same-id"]).toMatchObject({
+      label: "scope-2",
+    });
+  });
+});

--- a/packages/models/__tests__/union.test.ts
+++ b/packages/models/__tests__/union.test.ts
@@ -433,6 +433,32 @@ describe("lens(union).where()", () => {
 });
 
 // ---------------------------------------------------------------------------
+// lens(union).delete()
+// ---------------------------------------------------------------------------
+
+describe("lens(union).delete() via scope", () => {
+  test("removes instances from the correct variant $instances", async () => {
+    const a = makeCounter();
+    const b = makeCounter();
+    a.create({ id: "a1", data: { count: 1 } });
+    b.create({ id: "b1", data: { count: 2 } });
+
+    const l = lens(union({ a, b }));
+    const trigger = createEvent<void>();
+    sample({
+      clock: trigger,
+      target: l.where((e) => e["~model"] === "a").delete(),
+    });
+
+    const scope = forkWith(a, b);
+    await allSettled(trigger, { scope });
+
+    expect(scope.getState(a.$instances)["a1"]).toBeUndefined();
+    expect(scope.getState(b.$instances)["b1"]?.count).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // lens(union) per-key target() – scope mutations
 // ---------------------------------------------------------------------------
 

--- a/packages/models/lib/lens/lens.ts
+++ b/packages/models/lib/lens/lens.ts
@@ -5,6 +5,7 @@ import {
   launch,
   sample,
   type Event,
+  type EventCallable,
 } from "effector";
 import { type Model, type ModelApi } from "../models";
 import type {
@@ -200,6 +201,22 @@ function buildLensCore(getInstances: () => Record<string, any>) {
   };
 }
 
+function createLensDeleteEvent(
+  getSource: () => Record<string, any>,
+  deleteById: EventCallable<string>,
+) {
+  const deleteEvent = createEvent<void>();
+
+  const deleteFx = createEffect(() => {
+    for (const id of Object.keys(getSource())) {
+      launch(deleteById, id);
+    }
+  });
+
+  sample({ clock: deleteEvent, target: deleteFx });
+  return deleteEvent;
+}
+
 // ---- Union helpers ----
 
 /**
@@ -267,6 +284,20 @@ export function lens(input: Union<UnionMap> | Model<any, any>): any {
         activeKeys = keys;
         return lensObj;
       },
+      delete() {
+        const deleteEvent = createEvent<void>();
+        const deleteFx = createEffect(() => {
+          for (const entity of Object.values(getSource())) {
+            const variantKey = entity["~model"];
+            const m = unionInput.models[variantKey];
+            if (m) {
+              launch(m.delete, (entity).id);
+            }
+          }
+        });
+        sample({ clock: deleteEvent, target: deleteFx });
+        return deleteEvent;
+      },
       match(config: Record<string, (subLens: any) => any>) {
         const units: any[] = [];
 
@@ -308,6 +339,9 @@ export function lens(input: Union<UnionMap> | Model<any, any>): any {
             last() {
               subPredicates.push(basePredicates.last);
               return subLens;
+            },
+            delete() {
+              return createLensDeleteEvent(getSubSource, variantModel.delete);
             },
             ...exportModelApi(
               variantModel,
@@ -386,6 +420,9 @@ export function lens(input: Union<UnionMap> | Model<any, any>): any {
     last() {
       predicates.push(basePredicates.last);
       return lensObj;
+    },
+    delete() {
+      return createLensDeleteEvent(getSource, model.delete);
     },
     ...exportModelApi(model, () => predicates),
   };

--- a/packages/models/lib/lens/types.ts
+++ b/packages/models/lib/lens/types.ts
@@ -59,6 +59,7 @@ type LensApi<Input extends Model<any, any>, Props = never> = {
   ): Lens<Input, Props>;
   first(): Lens<Input, Props>;
   last(): Lens<Input, Props>;
+  delete(): EventCallable<void>;
 };
 
 // ---- Union lens types ----
@@ -135,6 +136,7 @@ export type UnionLens<
           ctx: MatchCtx<U, Keys>,
         ) => boolean,
   ): UnionLens<U, Keys, Props>;
+  delete(): EventCallable<void>;
   match<
     Config extends {
       [K in Keys]?: (

--- a/packages/models/lib/models/models.ts
+++ b/packages/models/lib/models/models.ts
@@ -27,7 +27,8 @@ export function model<T extends Contract<any>, Api extends ModelApi>({
   const $instances =
     instances ?? createStore<Instances<T>>({}, { sid: `$instances/${sid}` });
 
-  const create = createEvent<CreateInstancePayload<T>>();
+  const createInstance = createEvent<CreateInstancePayload<T>>();
+  const deleteInstance = createEvent<string>();
 
   const { result: modelApi } = modifyDeclarations(() => {
     const api = createApi(contract);
@@ -36,7 +37,7 @@ export function model<T extends Contract<any>, Api extends ModelApi>({
   });
 
   sample({
-    clock: create,
+    clock: createInstance,
     source: $instances,
     fn: (instances, { id, data }) => ({
       ...instances,
@@ -46,6 +47,16 @@ export function model<T extends Contract<any>, Api extends ModelApi>({
     }),
     target: $instances,
   });
+
+  sample({
+    clock: deleteInstance,
+    source: $instances,
+    fn: (instances, id) => {
+      const { [id]: _, ...rest } = instances;
+      return rest;
+    },
+    target: $instances,
+  })
 
   const builtModel = {
     "~kind": "model",
@@ -58,7 +69,8 @@ export function model<T extends Contract<any>, Api extends ModelApi>({
 
     $instances,
 
-    create,
+    create: createInstance,
+    delete: deleteInstance,
   };
 
   return Object.assign(builtModel, {

--- a/packages/models/lib/models/types.ts
+++ b/packages/models/lib/models/types.ts
@@ -75,6 +75,7 @@ export interface Model<T extends Contract<any>, Api extends ModelApi> {
 
   $instances: Store<Record<string, BaseInstance & ContractData<T>>>;
   create: EventCallable<CreateInstancePayload<T>>;
+  delete: EventCallable<string>;
 
   lens: Lens<Model<T, Api>> & LensProps<Model<T, Api>>;
 


### PR DESCRIPTION
reference issue: https://github.com/movpushmov/effector-kit/issues/2
Added two ways of model instance deletion
1. Via model api: model.delete("1")
2. Via lens event
```
const removeA = createEvent<void>();
sample({
  clock: removeA,
  target: m.lens.where(({ tag }) => tag === "a").delete(),
});
```