### PR TITLE
fix(models): dedupe tracked ref ids

### DIFF
--- a/packages/models/__tests__/requirements.test.ts
+++ b/packages/models/__tests__/requirements.test.ts
@@ -137,6 +137,7 @@ function createDashboardModel() {
         setSelectedCount,
         deleteSelected,
         selectedCountChanged: selected.lens.count.clock(),
+        selected,
       };
     },
   });
@@ -668,6 +669,66 @@ describe("models api", () => {
       expect(scope.getState(counterModel.$instances)).toMatchObject({
         a: { count: 1 },
         b: { count: 20 },
+      });
+    });
+
+    test("does not duplicate tracked ref ids when tracking the same id repeatedly", async () => {
+      const scope = fork();
+
+      await createInstances(scope, counterModel.create, [
+        { id: "a", data: { count: 1 } },
+        { id: "b", data: { count: 2 } },
+      ]);
+
+      const dashboardModel = createDashboardModel();
+
+      await createInstances(scope, dashboardModel.create, [
+        { id: "d1", data: { name: "Dashboard #1" } },
+      ]);
+
+      await allSettled(
+        dashboardModel.lens.where((entity) => entity.id === "d1").track.target(),
+        {
+          scope,
+          params: "a",
+        },
+      );
+
+      await allSettled(
+        dashboardModel.lens.where((entity) => entity.id === "d1").track.target(),
+        {
+          scope,
+          params: "a",
+        },
+      );
+
+      await allSettled(
+        dashboardModel.lens.where((entity) => entity.id === "d1").track.target(),
+        {
+          scope,
+          params: "a",
+        },
+      );
+
+      await allSettled(
+        dashboardModel.lens
+          .where((entity) => entity.id === "d1")
+          .setSelectedCount.target(),
+        {
+          scope,
+          params: 10,
+        },
+      );
+
+      expect(scope.getState(counterModel.$instances)).toStrictEqual({
+        a: { count: 10 },
+        b: { count: 2 },
+      });
+
+      const counterModelRefId = dashboardModel["~api"].selected["~id"];
+
+      expect(scope.getState(dashboardModel.$instances)).toMatchObject({
+        d1: { name: "Dashboard #1", "~refs": { [counterModelRefId]: ["a"] } },
       });
     });
 

--- a/packages/models/lib/ref/ref.ts
+++ b/packages/models/lib/ref/ref.ts
@@ -122,6 +122,8 @@ export function ref(input: Union<UnionMap> | Model<any, any>): Ref<any> {
       sample({
         clock: addKey,
         source: $ids,
+        filter: (ids, id) =>
+          !ids.some((item) => item.key === key && item.id === id),
         fn: (ids, id) => [...ids, { key, id }],
         target: $ids,
       });
@@ -160,6 +162,7 @@ export function ref(input: Union<UnionMap> | Model<any, any>): Ref<any> {
   sample({
     clock: add,
     source: $ids,
+    filter: (ids, id) => !ids.includes(id),
     fn: (ids, id) => [...ids, id],
     target: $ids,
   });


### PR DESCRIPTION
## Summary

- Prevent `ref.add` from appending the same tracked id more than once.
- Apply the same deduplication to union refs by checking the `{ key, id }` pair.
- Add regression coverage for repeated `track` calls with the same id.

## Testing

- `pnpm --filter @effector-kit/models test`
- `pnpm --filter @effector-kit/models build`

## Notes

No changeset is included in this PR.